### PR TITLE
NEON-432 - Fire new IVs when horizontal carousels come into view

### DIFF
--- a/js/basic_modules.js.template
+++ b/js/basic_modules.js.template
@@ -206,7 +206,7 @@ Object.size = function(obj) {
         },
 
         beacon: function() {
-            if (true) {
+            if (false) {
                 console.log(arguments);
             }
         },
@@ -490,7 +490,7 @@ Object.size = function(obj) {
 
         }
         catch(err) {
-            console.log('registerClick', err);
+            // console.log('registerClick', err);
         }   
     }
 

--- a/neon_main_2089095449.js
+++ b/neon_main_2089095449.js
@@ -207,7 +207,7 @@ Object.size = function(obj) {
         },
 
         beacon: function() {
-            if (true) {
+            if (false) {
                 console.log(arguments);
             }
         },
@@ -491,7 +491,7 @@ Object.size = function(obj) {
 
         }
         catch(err) {
-            console.log('registerClick', err);
+            // console.log('registerClick', err);
         }   
     }
 

--- a/neon_main_2089095449.js
+++ b/neon_main_2089095449.js
@@ -1,4 +1,5 @@
-var _neon = _neon || {},
+var neonPublisherId = '2089095449';
+var neonTrackerType = 'gen';var _neon = _neon || {},
     neonPageId = null,
     videoIds = [],
     imgObjs = [],
@@ -1280,4 +1281,38 @@ _neon.TrackerEvents = (function() {
     }
 
 }());
-    
+    //Main function
+(function() {
+    //We do not want the script to execute this main function while unit testing
+    if(_neon.UNITTEST) return;
+
+    var docReadyId = setInterval(NeonInit, 100); //100ms
+
+    /// Neon Init method
+    function NeonInit(){
+        if(document.readyState === "complete" || document.readyState === "interactive"){
+            //Clear the data on viewed thumbnails in session storage 
+            //and update the TS in local storage	
+            _neon.StorageModule.clearPageSessionData();
+            clearInterval(docReadyId);
+
+            /// IPAD Clicks
+            $(document).bind("touchstart", function(e){
+                // Record any touch start on the canvas (best effort)
+                lastMouseClick = new Date().getTime();
+            });
+
+        }
+
+    }
+
+    /// TODO: Handle this globally and resort to storing things in memory
+    //run the tracker only on browsers that can suppport it
+    if(sessionStorage && localStorage && JSON) {
+        _neon.tracker.init();
+    }
+})();
+
+})(_neonjQuery); //end of _neon obj
+
+


### PR DESCRIPTION
- some additional functionality to consistently check src and data-original on images
- bug was fixed by making sure that when we originally make a list of all Neon images we included those that are lazy loaded (data-original), we were only checking items that match a src selector
- combining vars
- tabbing
- missing { and } added
- spacing around braces
- “ -> ‘
- Some loop speedup
