### PR TITLE
CNN clicks not being registered on text #703 

### DIFF
--- a/_partials/cnn.register-click-event.js
+++ b/_partials/cnn.register-click-event.js
@@ -5,6 +5,6 @@ if ($elParent.is('a')) {
 	$el = $elParent;
 }
 
-$elBonusEl = $($el.closest('.cd--article').find('.cd__headline a')[0]);
+$elBonusEl = $($el.closest('.cd--card').find('.cd__headline a')[0]);
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/js/basic_modules.js.template
+++ b/js/basic_modules.js.template
@@ -607,11 +607,11 @@ Object.size = function(obj) {
 
         function masterControlProgram(bindForNewContent) {
             mapImagesToTids();
-                if (bindForNewContent) {
-                    $(document.body).bind('DOMNodeInserted.neon', function(e) {
-                }
-                getNewImages(e.target);
-            });
+            if (bindForNewContent) {
+                $(document.body).bind('DOMNodeInserted.neon', function(e) {
+                    getNewImages(e.target);
+                });
+            }
             startISPSubmitInterval();
         }
 


### PR DESCRIPTION
- use more common selector for both `/us` and `/entertainment` pages
- bracket error and whitespace fix
