### PR TITLE
Fox Tweaks #702

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Temp repo for Neon tracker v2
 ### FOX
 
 - ```./generate_tracker.py --trackerid 1930337906```
+- ```./generate_tracker.py --trackerid 1930337906 --minify 0 --upload_location s3test```
 
 ### CNN
 - ```./generate_tracker.py --trackerid 1657678658```

--- a/_partials/fox.register-click-event.js
+++ b/_partials/fox.register-click-event.js
@@ -1,16 +1,10 @@
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-var $elParent = $el.parent();
-if ($elParent.is('a.neonized-image')) {
-	$el = $elParent;
-}
-
-// Try Mobile
-$elBonusEl = $($el.closest('.views-row').find('.info .views-field-title a')[0]);
-
-// Try Desktop
-if ((typeof $elBonusEl != 'undefined') && ($elBonusEl.length === 0)) {
-	$elBonusEl = $($el.closest('.fox-video-full-episodes-listing').find('.views-field-title a')[0]);
-}
+Array.prototype.push.apply(extraElements, $el.closest('.views-row').find('a'));
+Array.prototype.push.apply(extraElements, $el.closest('.views-field').find('a'));
+Array.prototype.push.apply(extraElements, $el.closest('.ep-result').find('a'));
+Array.prototype.push.apply(extraElements, $el.closest('.content-grid-item').find('a'));
+Array.prototype.push.apply(extraElements, $el.closest('.views-field-field-image-thumb').find('a'));
+$el = undefined;
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/js/basic_modules.js.template
+++ b/js/basic_modules.js.template
@@ -472,24 +472,35 @@ Object.size = function(obj) {
 
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
-        function _registerClickEvent($el) {
+        function _registerClickEvent($elToCheck) {
             
-            var clickAttr = _neon.utils.getMysteryElementImageSource($el),
+            var $el = $elToCheck,
+                clickAttr = _neon.utils.getMysteryElementImageSource($el),
+                extraElements = [],
                 $elBonusEl // if you need to add a bonus Element, do so in a partial
             ;
 
             {% include fox.register-click-event.js id="1930337906" %}
             {% include cnn.register-click-event.js id="1657678658" %}
             
-            _clickHandlerOff($el);
-            _clickHandlerOn($el, clickAttr, imageClickEventHandler);
-            _neon.utils.beacon('_registerClickEvent' + ' added', clickAttr);
+            if ((typeof $el != 'undefined') && ($el.length === 1)) {            
+                _clickHandlerOff($el);
+                _clickHandlerOn($el, clickAttr, imageClickEventHandler);
+                _neon.utils.beacon('_registerClickEvent' + ' added', clickAttr);
+            }
 
             if ((typeof $elBonusEl != 'undefined') && ($elBonusEl.length === 1)) {
                 _clickHandlerOff($elBonusEl);
                 _clickHandlerOn($elBonusEl, clickAttr, imageClickEventHandler);
                 _neon.utils.beacon('Bonus _registerClickEvent' + ' added', clickAttr);
             }
+
+            extraElements.forEach(function(extraElement) {
+                var $extraElement = $(extraElement);
+                _clickHandlerOff($extraElement);
+                _clickHandlerOn($extraElement, clickAttr, imageClickEventHandler);
+                _neon.utils.beacon('Extra _registerClickEvent' + ' added', clickAttr);
+            });
         }
 
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 


### PR DESCRIPTION
- changed approach to looking for elements with `extraElements`
- changed Fox code to kill `$el` as its not being used, the clicks are being put on the anchors that are all within a common ancestor
- bonus loop to iterate the `extraElements`
- `README` tweak
