### PR TITLE
Tracking Solution for Gallery #983

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,62 @@
-# neontrackerstratchpad
-
-Temp repo for Neon tracker v2
-
-## Release process 
-
-```sh minifier.sh js/neon.js js/neon-main.js```
-
-```sh minifier.sh js/neonbootloader.js js/neonbctracker.js```
+# tracker
 
 ## Generation
 
-### Gannett
+There are many options. `generate_tracker.py` has a definitive list but:
 
-- ```./generate_tracker.py --trackerid 1554964958 --custom_module 'js/neonbcoveplayer.js'```
-- ```./generate_tracker.py --trackerid 1554964958 --minify 1 --upload_location s3prod --custom_module 'js/neonbcoveplayer.js'```
+- `--upload_location` can be `s3test` or `s3prod`
+- `--trackerid 1234567890` (optional, see Dixon)
+- `--upload_location` can be `simple` or (defaults to) `normal`
+- `--minify` can be `0` or `1` 
 
-### FOX
+## Dixon (generic)
 
-- ```./generate_tracker.py --trackerid 1930337906```
-- ```./generate_tracker.py --trackerid 1930337906 --minify 0 --upload_location s3test```
+We can generate without a `trackerid`, e.g.:
 
-### CNN
-- ```./generate_tracker.py --trackerid 1657678658```
-- ```./generate_tracker.py --trackerid 1657678658 --minify 1 --upload_location s3prod```
+- `./generate_tracker.py --minify 0 --upload_location s3test`
+- `./generate_tracker.py --minify 1 --upload_location s3prod`
+
+* Note to test somewhat and see snippet, run a local web server and point at `http://localhost/dixon/snippet.html`
+
+## Snippets
+
+### Brightcove Gallery + Test
+
+```javascript
+<script id="neon">
+    var neonPublisherId = 'XXXXXXXXXX';
+    var neonBrightcoveGallery = true;
+</script>
+<script src="//neon-test.s3.amazonaws.com/neonoptimizer_dixon.js"></script>
+```
+
+### Brightcove Gallery + Production
+
+```javascript
+<script id="neon">
+    var neonPublisherId = 'XXXXXXXXXX';
+    var neonBrightcoveGallery = true;
+</script>
+<script src="//cdn.neon-lab.com/neonoptimizer_dixon.js"></script>
+```
+
+### NOT Brightcove Gallery + Test
+
+```javascript
+<script id="neon">
+    var neonPublisherId = 'XXXXXXXXXX';
+</script>
+<script src="//neon-test.s3.amazonaws.com/neonoptimizer_dixon.js"></script>
+```
+
+### NOT Brightcove Gallery + Production
+
+```javascript
+<script id="neon">
+    var neonPublisherId = 'XXXXXXXXXX';
+</script>
+<script src="//cdn.neon-lab.com/neonoptimizer_dixon.js"></script>
+```
 
 ## includes
 
@@ -68,3 +102,24 @@ If you run
 
 - You should see an error in the console AND in the generated file `neon_main_123456789.js`.
 - You should also see the contents of `123456789.test.js` included into `neon_main_123456789.js`
+
+## Examples
+
+### Gannett
+
+- ```./generate_tracker.py --trackerid 1554964958 --custom_module 'js/neonbcoveplayer.js'```
+- ```./generate_tracker.py --trackerid 1554964958 --minify 1 --upload_location s3prod --custom_module 'js/neonbcoveplayer.js'```
+
+### FOX
+
+- ```./generate_tracker.py --trackerid 1930337906```
+- ```./generate_tracker.py --trackerid 1930337906 --minify 0 --upload_location s3test```
+
+### CNN
+- ```./generate_tracker.py --trackerid 1657678658```
+- ```./generate_tracker.py --trackerid 1657678658 --minify 1 --upload_location s3prod```
+
+## Release process 
+
+- ```sh minifier.sh js/neon.js js/neon-main.js```
+- ```sh minifier.sh js/neonbootloader.js js/neonbctracker.js```

--- a/dixon/snippet.html
+++ b/dixon/snippet.html
@@ -1,0 +1,40 @@
+<html>
+    <head>
+        <title>Dixon | Neon</title>
+       
+        <script id="neon">
+        var neonPublisherId = '1830901739';
+        var neonBrightcoveGallery = true;
+        </script>
+        <script src="//cdn.neon-lab.com/neonoptimizer_dixon.js"></script>
+
+        <style>
+            textarea {
+                font-family: monospace;
+                width: 100%;
+                font-size: 1em;
+            }
+        </style>
+
+    </head>
+    <body>
+
+        <h2>Experiments</h2>
+
+        <h3><a href="http://yahoo.com/">Regular Image</a></h3>
+        <a href="http://yahoo.com/">
+            <img src="http://i3.neon-images.com/v1/client/1830901739/neonvid_152655.006.01.197.jpg" width="100" height="100" />
+        </a>
+
+        <a href="http://aol.com/">
+            <img src="https://images.gallerysites.net/?image=http://i3.neon-images.com/v1/client/1830901739/neonvid_149293.043.01.197.jpg?width=640&height=360&width=622&height=350" />
+        </a>
+
+        <h3>Background Image</h3>
+
+        <a href="http://google.com/">
+            <div style="width: 100px;height: 100px; background-image: url('http://i3.neon-images.com/v1/client/1830901739/neonvid_149293.043.01.197.jpg?width=337&height=337');"></div>
+        </a>
+
+    </body>
+</html>

--- a/js/basic_modules.js.template
+++ b/js/basic_modules.js.template
@@ -1,5 +1,4 @@
 var _neon = _neon || {},
-    neonPageId = null,
     videoIds = [],
     imgObjs = [],
     BASE_NEON_IMAGES_URL = 'neon-images.com',
@@ -356,8 +355,44 @@ Object.size = function(obj) {
             initialLoadComplete = false, 
             lastClickedImage = null,
             lastClickOnNeonElementTs = null,
-            lastClickOnNeonElement = null
+            lastClickOnNeonElement = null,
+            simpleMap = {}
         ;
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
+        if (neonTrackerMode === 'simple') {
+            // We need to watch ALL anchors if one is clicked, see if we have
+            // a note of it, if so get the vid/tid and if that works, fire an
+            // IC
+            $(document.body).on('click', 'a', function(e) {
+                var imageurl = _getSimpleMapFire(e.currentTarget.href);
+                if (imageurl) {
+                    var thumbData = _neon.tracker.getDataFromUrl(url);
+                    if (thumbData) {
+                        var vid = thumbData[0],
+                            tid = thumbData[1]
+                        ;
+                        if (vid && tid) {
+                            _neon.TrackerEvents.sendImageClickEvent(vid, tid);
+                        }
+                    }
+                }
+            });
+        }
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
+        function _getSimpleMapFire(url) {
+            if (simpleMap && simpleMap.hasOwnProperty(url)) {
+                return simpleMap[url];
+            }
+            else {
+                return false;
+            }
+        }
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
         // Find adjacent elements with same link
         // This is to handle cases where headlines and images have the same link
@@ -473,17 +508,36 @@ Object.size = function(obj) {
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
         function _registerClickEvent($elToCheck) {
-            
+
             var $el = $elToCheck,
-                clickAttr = _neon.utils.getMysteryElementImageSource($el),
-                extraElements = [],
+                clickAttr = _neon.utils.getMysteryElementImageSource($el)
+            ;
+
+            // mode=simple
+            if (neonTrackerMode === 'simple') {
+                // We look for the anchor
+                var $a = $el.closest('a');
+                if ((typeof $a != 'undefined') && ($a.length === 1)) {
+                    var aHref = $a.attr('href');
+                    if (aHref) {
+                        if (aHref.indexOf('#') === 0) {
+                            aHref = window.location.href + aHref;
+                        }
+                        simpleMap[aHref] = clickAttr;
+                    }
+                }
+            }
+
+            // mode=normal
+
+            var extraElements = [],
                 $elBonusEl // if you need to add a bonus Element, do so in a partial
             ;
 
             {% include fox.register-click-event.js id="1930337906" %}
             {% include cnn.register-click-event.js id="1657678658" %}
             
-            if ((typeof $el != 'undefined') && ($el.length === 1)) {            
+            if ((typeof $el != 'undefined') && ($el.length === 1)) {
                 _clickHandlerOff($el);
                 _clickHandlerOn($el, clickAttr, imageClickEventHandler);
                 _neon.utils.beacon('_registerClickEvent' + ' added', clickAttr);
@@ -539,18 +593,20 @@ Object.size = function(obj) {
             }
         }
 
-        // Get thumbnail ids and video_id for images from URL
-        function getNeonThumbnailIdsFromISP(videoIds, getThumbCallback) {
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
-            if (videoIds.length < 1) {
-                getThumbCallback(imgObjs, videoIds, '');
+        // Get thumbnail ids and video_id for images from URL
+        function getNeonThumbnailIdsFromISP(vids, getThumbCallback) {
+
+            if (vids.length < 1) {
+                getThumbCallback(imgObjs, vids, '');
                 return;
             }
 
             var publisherId = _neon.tracker.getNeonPublisherId(),
                 serviceURL = 'http://' + apiBaseURL + '/v1/getthumbnailid/';
 
-            serviceURL +=  publisherId + '.html?params=' + videoIds.join(); 
+            serviceURL +=  publisherId + '.html?params=' + vids.join(); 
 
             var new_i_frame = document.createElement('iframe');
             $('body').append(new_i_frame);
@@ -558,6 +614,8 @@ Object.size = function(obj) {
             new_i_frame.id = publisherId;
             new_i_frame.src = serviceURL;
         }
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
         function imageHunter(rootElement) {
             var $elements = _neon.utils.getElementsUsingImageSourceSelector('', rootElement);
@@ -567,7 +625,9 @@ Object.size = function(obj) {
                });  
             }
         }
-    
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
         function getNewImages(element) {
             if (initialLoadComplete) {
                 imageHunter(element);
@@ -592,6 +652,8 @@ Object.size = function(obj) {
             }
             videoIdsCount = videoIds.length; 
         } 
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
         function _testAndAddImageElement(potentialElement) {
             var $element = _neon.utils.makeJQueryObject(potentialElement),
@@ -867,6 +929,16 @@ Object.size = function(obj) {
                 parseTrackerAccountId(); 
             },
 
+            addVideoId: function(videoId) {
+                if (videoIds.indexOf(videoId) === -1) {
+                    videoIds.push(videoId);
+                }
+            },
+
+            getVideoIds: function() {
+                return videoIds;
+            },
+
             // Get the Tracker AccountID from the script tag "id" field
             // Or from the filename of the optimizer script
             getTrackerAccountId: function() {
@@ -897,6 +969,14 @@ Object.size = function(obj) {
 
             getNeonPublisherId: function() {
                 return trackerAccountId; 
+            },
+
+            getDataFromUrl: function(url) {
+                var thumbData;
+                if (thumbMap && thumbMap.hasOwnProperty(url)) {
+                    thumbData = thumbMap[url];
+                }
+                return thumbData;
             },
             
             reInitNeon: reInitNeon,
@@ -1149,6 +1229,7 @@ _neon.TrackerEvents = (function() {
     }
 
     return {
+
         // tid: thumbnail id
         // wx, wy: window xy coordinate
         // px, py: page xy coordinate
@@ -1166,6 +1247,21 @@ _neon.TrackerEvents = (function() {
             // Third Party Click Validators get called here
             {% include gannett.click.js id="1554964958" %}
             {% include gannett.click.js id="1600036805" %}
+        },
+
+        // Wrapper around sendImageClickEvent, we pass the url instead and use this
+        // to find the tid
+        sendImageClickEventByUrl: function(vid, url, wx, wy, px, py, cx, cy) {
+            var thumbData = _neon.tracker.getDataFromUrl(url);
+            try  {
+                var tid = thumbData[1];
+                sendImageClickEvent(vid, tid, wx, wy, px, py, cx, cy);
+                return true;
+            }
+            catch(err) {
+                _neon.utils.beacon('sendImageClickEventByUrl', 'Could not find tid for ' + url);
+                return false;
+            }
         },
 
         // PlayerID of the player, if available
@@ -1206,6 +1302,23 @@ _neon.TrackerEvents = (function() {
             }
         },
 
+        sendImageVisibleEventByUrl: function(url) {
+            var thumbData = _neon.tracker.getDataFromUrl(url);
+            try  {
+                var vid = thumbData[0],
+                    tid = thumbData[1],
+                    imageMap = {}
+                ;
+                imageMap[url] = [vid, tid];
+                sendImagesVisibleEvent(imageMap);
+                return true;
+            }
+            catch(err) {
+                _neon.utils.beacon('sendImageVisibleEventByUrl', 'Could not find vid/tid for ' + url);
+                return false;
+            }
+        },
+
         // ImageMap is a Map of thumbnail url => tid
         // imSizeMap is map of url => visible im size 
         sendImagesLoadedEvent: function(imageMap, imSizeMap) {
@@ -1216,6 +1329,25 @@ _neon.TrackerEvents = (function() {
                 req += '&tids=' + tids;
                 _neon.utils.beacon(eventName, tids.length, req);
                 _neon.JsonRequester.sendRequest(req);
+            }
+        },
+
+        sendImageLoadedEventByUrl: function(url, width, height) {
+            var thumbData = _neon.tracker.getDataFromUrl(url);
+            try  {
+                var vid = thumbData[0],
+                    tid = thumbData[1],
+                    imageMap = {},
+                    imSizeMap = {}
+                ;
+                imageMap[url] = [vid, tid];
+                imSizeMap[url] = [width, height];
+                sendImagesLoadedEvent(imageMap, imSizeMap);
+                return true;
+            }
+            catch(err) {
+                _neon.utils.beacon('sendImageLoadedEventByUrl', 'Could not find vid/tid for ' + url);
+                return false;
             }
         },
 
@@ -1239,4 +1371,3 @@ _neon.TrackerEvents = (function() {
     }
 
 }());
-    

--- a/js/bootloader.js.template
+++ b/js/bootloader.js.template
@@ -1,5 +1,138 @@
-LazyLoad=function(m){function d(b,a){var l=m.createElement(b),c;for(c in a)a.hasOwnProperty(c)&&l.setAttribute(c,a[c]);return l}function g(b){var a=q[b],c,d;a&&(c=a.callback,d=a.urls,d.shift(),k=0,d.length||(c&&c.call(a.context,a.obj),q[b]=null,t[b].length&&p(b)))}function h(){var b=navigator.userAgent;c={async:!0===m.createElement("script").async};(c.webkit=/AppleWebKit\//.test(b))||(c.ie=/MSIE|Trident/.test(b))||(c.opera=/Opera/.test(b))||(c.gecko=/Gecko\//.test(b))||(c.unknown=!0)}function p(b,
-a,l,k,p){var r=function(){g(b)},u="css"===b,v=[],f,n,e,w;c||h();if(a)if(a="string"===typeof a?[a]:a.concat(),u||c.async||c.gecko||c.opera)t[b].push({urls:a,callback:l,obj:k,context:p});else for(f=0,n=a.length;f<n;++f)t[b].push({urls:[a[f]],callback:f===n-1?l:null,obj:k,context:p});if(!q[b]&&(w=q[b]=t[b].shift())){x||(x=m.head||m.getElementsByTagName("head")[0]);a=w.urls.concat();f=0;for(n=a.length;f<n;++f)l=a[f],u?e=c.gecko?d("style"):d("link",{href:l,rel:"stylesheet"}):(e=d("script",{src:l}),e.async=
-!1),e.className="lazyload",e.setAttribute("charset","utf-8"),c.ie&&!u&&"onreadystatechange"in e&&!("draggable"in e)?e.onreadystatechange=function(){/loaded|complete/.test(e.readyState)&&(e.onreadystatechange=null,r())}:u&&(c.gecko||c.webkit)?c.webkit?(w.urls[f]=e.href,y()):(e.innerHTML='@import "'+l+'";',z(e)):e.onload=e.onerror=r,v.push(e);f=0;for(n=v.length;f<n;++f)x.appendChild(v[f])}}function z(b){var a;try{a=!!b.sheet.cssRules}catch(c){k+=1;200>k?setTimeout(function(){z(b)},50):a&&g("css");return}g("css")}
-function y(){var b=q.css,a;if(b){for(a=r.length;0<=--a;)if(r[a].href===b.urls[0]){g("css");break}k+=1;b&&(200>k?setTimeout(y,50):g("css"))}}var c,x,q={},k=0,t={css:[],js:[]},r=m.styleSheets;return{css:function(b,a,c,d){p("css",b,a,c,d)},js:function(b,a,c,d){p("js",b,a,c,d)}}}(this.document);
-(function(){function m(){var d;d="undefined"!=typeof jQuery?jQuery.fn.jquery:!1;if(d){d=d.split(".");for(var g=["1","10","0"],h=0;h<d.length;h++)d[h]=parseInt(d[h],10);for(h=0;h<g.length;h++)g[h]=parseInt(g[h],10);if(d[0]>g[0])return!1;if(d[0]<g[0])return!0;if(d[1]>=g[1])return!1}return!0}(function(){m()?LazyLoad.js("//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js",function(){_neonjQuery=$.noConflict(!0);LazyLoad.js("MAIN_JS_URL",function(){})}):(_neonjQuery=jQuery,LazyLoad.js("MAIN_JS_URL",function(){}))})()})();
+if (typeof isNeonBrightcoveGallery === 'undefined') {
+    var isNeonBrightcoveGallery = false;
+}
+if (isNeonBrightcoveGallery) {
+    var b = document.body.innerHTML;
+    document.body.innerHTML = b.replace(/https?:\/\/images.gallerysites.net\/?\?image=(.*)\?.*(width=\d+(\&|\&amp;)height=\d+)/g, '$1?$2');
+}
+
+LazyLoad = function(m) {
+    function d(b, a) {
+        var l = m.createElement(b),
+            c;
+        for (c in a) a.hasOwnProperty(c) && l.setAttribute(c, a[c]);
+        return l
+    }
+
+    function g(b) {
+        var a = q[b],
+            c, d;
+        a && (c = a.callback, d = a.urls, d.shift(), k = 0, d.length || (c && c.call(a.context, a.obj), q[b] = null, t[b].length && p(b)))
+    }
+
+    function h() {
+        var b = navigator.userAgent;
+        c = {
+            async: !0 === m.createElement("script").async
+        };
+        (c.webkit = /AppleWebKit\//.test(b)) || (c.ie = /MSIE|Trident/.test(b)) || (c.opera = /Opera/.test(b)) || (c.gecko = /Gecko\//.test(b)) || (c.unknown = !0)
+    }
+
+    function p(b,
+        a, l, k, p) {
+        var r = function() {
+                g(b)
+            },
+            u = "css" === b,
+            v = [],
+            f, n, e, w;
+        c || h();
+        if (a)
+            if (a = "string" === typeof a ? [a] : a.concat(), u || c.async || c.gecko || c.opera) t[b].push({
+                urls: a,
+                callback: l,
+                obj: k,
+                context: p
+            });
+            else
+                for (f = 0, n = a.length; f < n; ++f) t[b].push({
+                    urls: [a[f]],
+                    callback: f === n - 1 ? l : null,
+                    obj: k,
+                    context: p
+                });
+        if (!q[b] && (w = q[b] = t[b].shift())) {
+            x || (x = m.head || m.getElementsByTagName("head")[0]);
+            a = w.urls.concat();
+            f = 0;
+            for (n = a.length; f < n; ++f) l = a[f], u ? e = c.gecko ? d("style") : d("link", {
+                href: l,
+                rel: "stylesheet"
+            }) : (e = d("script", {
+                src: l
+            }), e.async = !1), e.className = "lazyload", e.setAttribute("charset", "utf-8"), c.ie && !u && "onreadystatechange" in e && !("draggable" in e) ? e.onreadystatechange = function() {
+                /loaded|complete/.test(e.readyState) && (e.onreadystatechange = null, r())
+            } : u && (c.gecko || c.webkit) ? c.webkit ? (w.urls[f] = e.href, y()) : (e.innerHTML = '@import "' + l + '";', z(e)) : e.onload = e.onerror = r, v.push(e);
+            f = 0;
+            for (n = v.length; f < n; ++f) x.appendChild(v[f])
+        }
+    }
+
+    function z(b) {
+        var a;
+        try {
+            a = !!b.sheet.cssRules
+        } catch (c) {
+            k += 1;
+            200 > k ? setTimeout(function() {
+                z(b)
+            }, 50) : a && g("css");
+            return
+        }
+        g("css")
+    }
+
+    function y() {
+        var b = q.css,
+            a;
+        if (b) {
+            for (a = r.length; 0 <= --a;)
+                if (r[a].href === b.urls[0]) {
+                    g("css");
+                    break
+                }
+            k += 1;
+            b && (200 > k ? setTimeout(y, 50) : g("css"))
+        }
+    }
+    var c, x, q = {},
+        k = 0,
+        t = {
+            css: [],
+            js: []
+        },
+        r = m.styleSheets;
+    return {
+        css: function(b, a, c, d) {
+            p("css", b, a, c, d)
+        },
+        js: function(b, a, c, d) {
+            p("js", b, a, c, d)
+        }
+    }
+}(this.document);
+
+(function() {
+
+    function m() {
+        var d;
+        d = "undefined" != typeof jQuery ? jQuery.fn.jquery : !1;
+        if (d) {
+            d = d.split(".");
+            for (var g = ["1", "10", "0"], h = 0; h < d.length; h++) d[h] = parseInt(d[h], 10);
+            for (h = 0; h < g.length; h++) g[h] = parseInt(g[h], 10);
+            if (d[0] > g[0]) return !1;
+            if (d[0] < g[0]) return !0;
+            if (d[1] >= g[1]) return !1
+        }
+        return !0
+    }
+
+    (function() {
+        m() ? LazyLoad.js("//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js", function() {
+            _neonjQuery = $.noConflict(!0);
+            LazyLoad.js("MAIN_JS_URL", function() {})
+        }) : (_neonjQuery = jQuery, LazyLoad.js("MAIN_JS_URL", function() {}))
+    })()
+
+})();


### PR DESCRIPTION
- allow generation to take place with no `trackerId`
- using `dixon` when no `trackerId` is specified
- updated `README`
- added snippet test page
- rename local `videoIds` -> `vids`
- remove unused `neonPageId` variable
- add `addVideoId` method which takes a `videoId` and pushes it to the `videoId` array
- added `_getTidFromUrl` function
- `sendImageLoadedEventByUrl` wrapper function added
- `sendImageClickEventByUrl` wrapper function added
- `sendImageVisibleEventByUrl` wrapper function added
- added mode to the generator which accepts `normal` (default) and `simple`
- in simple mode we only look for Neon images in anchors
- simpleMap holds (`href` -> `imageUrl`) for all Neon images we find, we watch all anchor clicks and if one fires, we check the simpleMap to see if the `href` is a match, if so we pull the `imageUrl`, get the `thumbData` (`tid` and `vid`) and fire an `image click`. This works on images, background images and a headline with the same anchor url as one of the images.
