### PR TITLE
Brightcove Gallery - Tracker decache doesn't pick up some URLs #1098

### DIFF
--- a/js/basic_modules.js.template
+++ b/js/basic_modules.js.template
@@ -526,6 +526,7 @@ Object.size = function(obj) {
                         simpleMap[aHref] = clickAttr;
                     }
                 }
+                return true;
             }
 
             // mode=normal

--- a/js/bootloader.js.template
+++ b/js/bootloader.js.template
@@ -5,7 +5,28 @@ if (typeof isNeonBrightcoveGallery === 'undefined') {
 }
 
 var neonDecacheBrightcoveGallery = function(str) {
-    return str.replace(/\/\/images.gallerysites.net\/?\?image=(.*)\?.*(width=\d+(\&|\&amp;)height=\d+)/g, '$1?$2');
+    return str.replace(/(https?:)?\/\/images\.gallerysites\.net\/?\?image=(.*jpg)(.*?)(\'\)|\")/g, function(match, p1, p2, p3, p4, offset, string) {
+        var goodQuerystring = {}
+            returnValue = p2,
+            querystringDirty = false,
+            cleanp3 = p3.replace('&amp;', '&') // sigh
+        ;
+        cleanp3.replace(
+            new RegExp("([^?=&]+)(=([^&]*))?", "g"), function($0, $1, $2, $3) {
+                goodQuerystring[$1] = $3;
+            }
+        );
+        if (goodQuerystring && goodQuerystring.hasOwnProperty('width')) {
+            returnValue += '?' + 'width=' + goodQuerystring['width'];
+            querystringDirty = true;
+        }
+        if (goodQuerystring && goodQuerystring.hasOwnProperty('height')) {
+            returnValue += (querystringDirty ? '&' : '?') + 'height=' + goodQuerystring['height'];
+            querystringDirty = true;
+        }
+        returnValue += p4;
+        return returnValue;
+    });
 }
 
 if (isNeonBrightcoveGallery) {


### PR DESCRIPTION
- added distinct decache section
- added `neonDecacheBrightcoveGallery` function
- also tweaked the regular expression to not include `http//`,
  `https://` or `//`
