### PR TITLE
Some Brightcove Gallery templates don't follow the simple convention #1102

### DIFF
--- a/js/bootloader.js.template
+++ b/js/bootloader.js.template
@@ -5,32 +5,33 @@ if (typeof isNeonBrightcoveGallery === 'undefined') {
 }
 
 var neonDecacheBrightcoveGallery = function(str) {
-    return str.replace(/(https?:)?\/\/images\.gallerysites\.net\/?\?image=(.*jpg)(.*?)(\'\)|\")/g, function(match, p1, p2, p3, p4, offset, string) {
+    return str.replace(/(https?:)?\/\/images\.gallerysites\.net\/?\?image=(.*jpg)\??(width=\d*|height=\d*|&amp;|&)*/g, function(match, p1, p2, p3, offset, string) {
         var goodQuerystring = {}
             returnValue = p2,
-            querystringDirty = false,
-            cleanp3 = p3.replace(/\&amp\;/g, '&') // sigh
+            querystringDirty = false
         ;
-        cleanp3.replace(
-            new RegExp("([^?=&]+)(=([^&]*))?", "g"), function($0, $1, $2, $3) {
-                goodQuerystring[$1] = $3;
+        if (p3) {
+            var cleanp3 = p3.replace(/\&amp\;/g, '&'); // sigh
+            cleanp3.replace(
+                new RegExp("([^?=&]+)(=([^&]*))?", "g"), function($0, $1, $2, $3) {
+                    goodQuerystring[$1] = $3;
+                }
+            );
+            if (goodQuerystring && goodQuerystring.hasOwnProperty('width')) {
+                returnValue += '?' + 'width=' + goodQuerystring['width'];
+                querystringDirty = true;
             }
-        );
-        if (goodQuerystring && goodQuerystring.hasOwnProperty('width')) {
-            returnValue += '?' + 'width=' + goodQuerystring['width'];
-            querystringDirty = true;
+            if (goodQuerystring && goodQuerystring.hasOwnProperty('height')) {
+                returnValue += (querystringDirty ? '&' : '?') + 'height=' + goodQuerystring['height'];
+                querystringDirty = true;
+            }
         }
-        if (goodQuerystring && goodQuerystring.hasOwnProperty('height')) {
-            returnValue += (querystringDirty ? '&' : '?') + 'height=' + goodQuerystring['height'];
-            querystringDirty = true;
-        }
-        returnValue += p4;
         return returnValue;
     });
 }
 
 var neonDecache = function(str) {
-    if (typeof str === 'undefined') {
+    if (typeof str === 'undefined' || str === '') {
         return '';
     }
     if (isNeonBrightcoveGallery) {


### PR DESCRIPTION
- extra check for `''` to speed up
- better regular expression to be more explicit about hunting down the `width=`, `height=`, `&`
- also edge case when no querystring handled more gracefully
