### PR TITLE
MSN Tracker JS #1460

### DIFF
--- a/js/basic_modules.js.template
+++ b/js/basic_modules.js.template
@@ -1,7 +1,7 @@
 var _neon = _neon || {},
     videoIds = [],
     imgObjs = [],
-    BASE_NEON_IMAGES_URL = 'neon-images.com',
+    CDN_IMAGE_BASE = 'neon-images.com',
     apiBaseURL = 'i3.neon-images.com',
     TAG_NAME_BLACK_LIST = 'area, audio, base, canvas, col, colgroup, datalist, dialog, del, details, embed, head, iframe, img, input, ins, keygen, link, map, menu, menuitem, meta, noscript, object, optgroup, option, param, progress, script, select, source, style, summary, title, track, video',
     lastMouseClick,
@@ -324,7 +324,7 @@ Object.size = function(obj) {
 
         getElementsUsingImageSourceSelector: function(imageSource, rootElement) {
             
-            var specificSource = imageSource ? ('$="' + imageSource + '"') : ('*="' + BASE_NEON_IMAGES_URL + '"'),
+            var specificSource = imageSource ? ('$="' + imageSource + '"') : ('*="' + CDN_IMAGE_BASE + '"'),
                 $rootElement = _neon.utils.makeJQueryObject(rootElement),
                 $fgImages,
                 $bgImages
@@ -696,9 +696,9 @@ Object.size = function(obj) {
         function _testAndAddImageElement(potentialElement) {
             
             var $element = _neon.utils.makeJQueryObject(potentialElement),
-                url = _neon.utils.getMysteryElementImageSource($element)
+                url = ''
             ;
-            
+
             if (_isNeonThumbnail(url)) {
                 
                 // Decache the best we can. Since we know it has a neon signature
@@ -707,7 +707,7 @@ Object.size = function(obj) {
                 $element.attr('data-background-image', neonDecache($element.attr('data-background-image')));
                 $element.css('background-image', neonDecache($element.css('background-image')));
 
-                // Remember to get the new URL
+                // Get the new URL
                 url = _neon.utils.getMysteryElementImageSource($element);
 
                 var vid = _getNeonVideoIdFromURL(url);
@@ -967,19 +967,19 @@ Object.size = function(obj) {
         }
 
         function _getNeonVideoIdFromURL(url) {
-           if (url.indexOf('neontn') > -1) {
+            if (url.indexOf('neontn') > -1) {
                 var ret = _parseNeonThumbnailIdURL(url);
-                if (ret) {
-                    return ret[0];
-                }
-                else {
-                    return;
-                }
-           }
-           if (url.indexOf('neonvid') > -1) {
-               return _neonISPURLToVid(url);
-           }
-           return;
+                    if (ret) {
+                        return ret[0];
+                    }
+                    else {
+                        return;
+                    }
+            }
+            if (url.indexOf('neonvid') > -1) {
+                return _neonISPURLToVid(url);
+            }
+            return;
         }
 
         //////////////////////////////////////////////////////////////////////////////

--- a/js/basic_modules.js.template
+++ b/js/basic_modules.js.template
@@ -1,7 +1,7 @@
 var _neon = _neon || {},
     videoIds = [],
     imgObjs = [],
-    CDN_IMAGE_BASE = 'neon-images.com',
+    CDN_IMAGE_BASE = 'neon-',
     apiBaseURL = 'i3.neon-images.com',
     TAG_NAME_BLACK_LIST = 'area, audio, base, canvas, col, colgroup, datalist, dialog, del, details, embed, head, iframe, img, input, ins, keygen, link, map, menu, menuitem, meta, noscript, object, optgroup, option, param, progress, script, select, source, style, summary, title, track, video',
     lastMouseClick,
@@ -696,7 +696,7 @@ Object.size = function(obj) {
         function _testAndAddImageElement(potentialElement) {
             
             var $element = _neon.utils.makeJQueryObject(potentialElement),
-                url = ''
+                url = _neon.utils.getMysteryElementImageSource($element)
             ;
 
             if (_isNeonThumbnail(url)) {

--- a/js/bootloader.js.template
+++ b/js/bootloader.js.template
@@ -31,7 +31,9 @@ var neonDecache = function(str) {
     return str;
 }
 
-document.body.innerHTML = neonDecache(document.body.innerHTML);
+if (document.body) {
+    document.body.innerHTML = neonDecache(document.body.innerHTML);    
+}
 
 // --- decache ---
 

--- a/js/utility/msn/replacement.js
+++ b/js/utility/msn/replacement.js
@@ -1,48 +1,58 @@
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+// http://imagecdn.neon-lab.com/awx/neontnjq3y3e46t6fuzq6hzv16kkgs_WrapperTest_ce93ce468d9ebb7d1bb2c725ae0f764a_w300_h240.jpg
+// http://imagecdn.neon-lab.com/zK2/neontnjq3y3e46t6fuzq6hzv16kkgs_WrapperTest_f8c4881082bac74d840a2ed6832137cb_w300_h240.jpg
+// http://imagecdn.neon-lab.com/Xuf/neontnjq3y3e46t6fuzq6hzv16kkgs_WrapperTest_d026930a4f64a878691852b1ffc9bd9c_w300_h240.jpg
+// http://imagecdn.neon-lab.com/0RL/neontnjq3y3e46t6fuzq6hzv16kkgs_WrapperTest_cb7fc57440e7a5c6f9ab22298f3cafa4_w300_h240.jpg
+// http://imagecdn.neon-lab.com/CjK/neontnjq3y3e46t6fuzq6hzv16kkgs_WrapperTest_aaa579634777bd96f404ad372ac7a245_w300_h152.jpg
+
 var neonReplacements = {
-    'X': 'Y'
+    'http://img-s-msn-com.akamaized.net/tenant/amp/entityid/BBuXpYG.img?h=516&w=624&m=6&q=60&u=t&o=t&l=f&f=jpg&x=573&y=299': 'http://imagecdn.neon-lab.com/awx/neontnjq3y3e46t6fuzq6hzv16kkgs_WrapperTest_ce93ce468d9ebb7d1bb2c725ae0f764a_w300_h240.jpg'
 };
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 function neonTransform(neonReplacements) {
-    var $imageContainer = $('body');
     for (var key in neonReplacements) {
         var value = neonReplacements[key],
-            $matches = $imageContainer.find('img[src*="' + key + '"]')
+            images = document.querySelectorAll("img[src='" + key + "']")
         ;
-        $matches.each(function() {
-            $(this).attr('src', value);
+        images.forEach(function(image) {
+            image.src = value;
         });
     }
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-
-
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
-neonTransform(neonReplacements);
-
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
-$(function() {
-    var fileRef = document.createElement('script');
-    fileRef.setAttribute('type', 'text/javascript');
-    fileRef.setAttribute('src', '//neon-test.s3.amazonaws.com/neonoptimizer_603225904.js');
-    document.body.appendChild(fileRef);
-});
-
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
-window.neonInterval1 = setInterval(function() {
+window.nInterval1 = setInterval(function() {
+    console.log('ping nInterval1');
     if (window._neon !== undefined) {
         window._neon.tracker.masterControlProgram();
-        clearInterval(neonInterval1);
+        clearInterval(nInterval1);
+        console.log('kill nInterval1');
     }
 }, 500);
 
+window.nInterval2 = setInterval(function() {
+    console.log('ping nInterval2');
+    if (document.body) {
+        var fileRef = document.createElement('script');
+        fileRef.setAttribute('type', 'text/javascript');
+        fileRef.setAttribute('src', '//neon-test.s3.amazonaws.com/neonoptimizer_603225904.js');
+        document.body.appendChild(fileRef);
+        clearInterval(nInterval2);
+        console.log('kill nInterval2');
+    }
+}, 500);
+
+window.nInterval3 = setInterval(function() {
+    console.log('ping nInterval3');
+    if (document) {
+        neonTransform(neonReplacements);
+        clearInterval(nInterval3);
+        console.log('kill nInterval3');
+    }
+}, 500);
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/js/utility/msn/replacement.js
+++ b/js/utility/msn/replacement.js
@@ -1,13 +1,12 @@
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-// http://imagecdn.neon-lab.com/awx/neontnjq3y3e46t6fuzq6hzv16kkgs_WrapperTest_ce93ce468d9ebb7d1bb2c725ae0f764a_w300_h240.jpg
-// http://imagecdn.neon-lab.com/zK2/neontnjq3y3e46t6fuzq6hzv16kkgs_WrapperTest_f8c4881082bac74d840a2ed6832137cb_w300_h240.jpg
 // http://imagecdn.neon-lab.com/Xuf/neontnjq3y3e46t6fuzq6hzv16kkgs_WrapperTest_d026930a4f64a878691852b1ffc9bd9c_w300_h240.jpg
 // http://imagecdn.neon-lab.com/0RL/neontnjq3y3e46t6fuzq6hzv16kkgs_WrapperTest_cb7fc57440e7a5c6f9ab22298f3cafa4_w300_h240.jpg
 // http://imagecdn.neon-lab.com/CjK/neontnjq3y3e46t6fuzq6hzv16kkgs_WrapperTest_aaa579634777bd96f404ad372ac7a245_w300_h152.jpg
 
 var neonReplacements = {
-    'http://img-s-msn-com.akamaized.net/tenant/amp/entityid/BBuXpYG.img?h=516&w=624&m=6&q=60&u=t&o=t&l=f&f=jpg&x=573&y=299': 'http://imagecdn.neon-lab.com/awx/neontnjq3y3e46t6fuzq6hzv16kkgs_WrapperTest_ce93ce468d9ebb7d1bb2c725ae0f764a_w300_h240.jpg'
+    'http://img-s-msn-com.akamaized.net/tenant/amp/entityid/BBuXpYG.img?h=516&w=624&m=6&q=60&u=t&o=t&l=f&f=jpg&x=573&y=299': 'http://imagecdn.neon-lab.com/awx/neontnjq3y3e46t6fuzq6hzv16kkgs_WrapperTest_ce93ce468d9ebb7d1bb2c725ae0f764a_w300_h240.jpg',
+    'http://img-s-msn-com.akamaized.net/tenant/amp/entityid/BBuXgQA.img?h=240&w=300&m=6&q=60&u=t&o=t&l=f&f=jpg&x=318&y=104': 'http://imagecdn.neon-lab.com/zK2/neontnjq3y3e46t6fuzq6hzv16kkgs_WrapperTest_f8c4881082bac74d840a2ed6832137cb_w300_h240.jpg'
 };
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -25,37 +24,20 @@ function neonTransform(neonReplacements) {
     }
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+window.onload = function () {
+    neonTransform(neonReplacements);    
+    var fileRef = document.createElement('script');
+    fileRef.src = '//neon-test.s3.amazonaws.com/neonoptimizer_603225904.js';
+    document.getElementsByTagName('head')[0].appendChild(fileRef);
 
-var nInterval1 = setInterval(function() {
-    console.log('ping nInterval1');
-    if (window._neon !== undefined) {
-        window._neon.tracker.masterControlProgram();
-        clearInterval(nInterval1);
-        console.log('kill nInterval1');
-    }
-}, 500);
-
-var nInterval2 = setInterval(function() {
-    console.log('ping nInterval2');
-    if (document.body) {
-        var fileRef = document.createElement('script');
-        fileRef.setAttribute('type', 'text/javascript');
-        fileRef.setAttribute('src', '//neon-test.s3.amazonaws.com/neonoptimizer_603225904.js');
-        document.body.appendChild(fileRef);
-        clearInterval(nInterval2);
-        console.log('kill nInterval2');
-    }
-}, 500);
-
-var nInterval3 = setInterval(function() {
-    console.log('ping nInterval3');
-    var html = document.querySelector('html')
-    if (html.classList.contains('loaded')) {
-        neonTransform(neonReplacements);
-        clearInterval(nInterval3);
-        console.log('kill nInterval3');
-    }
-}, 500);
+    var nInterval1 = setInterval(function() {
+        console.log('ping nInterval1');
+        if (window._neon !== undefined) {
+            window._neon.tracker.masterControlProgram();
+            clearInterval(nInterval1);
+            console.log('kill nInterval1');
+        }
+    }, 500);
+}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/js/utility/msn/replacement.js
+++ b/js/utility/msn/replacement.js
@@ -1,0 +1,48 @@
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+var neonReplacements = {
+    'X': 'Y'
+};
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+function neonTransform(neonReplacements) {
+    var $imageContainer = $('body');
+    for (var key in neonReplacements) {
+        var value = neonReplacements[key],
+            $matches = $imageContainer.find('img[src*="' + key + '"]')
+        ;
+        $matches.each(function() {
+            $(this).attr('src', value);
+        });
+    }
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+neonTransform(neonReplacements);
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+$(function() {
+    var fileRef = document.createElement('script');
+    fileRef.setAttribute('type', 'text/javascript');
+    fileRef.setAttribute('src', '//neon-test.s3.amazonaws.com/neonoptimizer_603225904.js');
+    document.body.appendChild(fileRef);
+});
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+window.neonInterval1 = setInterval(function() {
+    if (window._neon !== undefined) {
+        window._neon.tracker.masterControlProgram();
+        clearInterval(neonInterval1);
+    }
+}, 500);
+
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/js/utility/msn/replacement.js
+++ b/js/utility/msn/replacement.js
@@ -18,14 +18,16 @@ function neonTransform(neonReplacements) {
             images = document.querySelectorAll("img[src='" + key + "']")
         ;
         images.forEach(function(image) {
-            image.src = value;
+            if (image.classList.contains('loaded')) {
+                image.src = value;
+            }
         });
     }
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-window.nInterval1 = setInterval(function() {
+var nInterval1 = setInterval(function() {
     console.log('ping nInterval1');
     if (window._neon !== undefined) {
         window._neon.tracker.masterControlProgram();
@@ -34,7 +36,7 @@ window.nInterval1 = setInterval(function() {
     }
 }, 500);
 
-window.nInterval2 = setInterval(function() {
+var nInterval2 = setInterval(function() {
     console.log('ping nInterval2');
     if (document.body) {
         var fileRef = document.createElement('script');
@@ -46,9 +48,10 @@ window.nInterval2 = setInterval(function() {
     }
 }, 500);
 
-window.nInterval3 = setInterval(function() {
+var nInterval3 = setInterval(function() {
     console.log('ping nInterval3');
-    if (document) {
+    var html = document.querySelector('html')
+    if (html.classList.contains('loaded')) {
         neonTransform(neonReplacements);
         clearInterval(nInterval3);
         console.log('kill nInterval3');

--- a/js/utility/msn/replacement.js
+++ b/js/utility/msn/replacement.js
@@ -1,12 +1,11 @@
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-// http://imagecdn.neon-lab.com/Xuf/neontnjq3y3e46t6fuzq6hzv16kkgs_WrapperTest_d026930a4f64a878691852b1ffc9bd9c_w300_h240.jpg
-// http://imagecdn.neon-lab.com/0RL/neontnjq3y3e46t6fuzq6hzv16kkgs_WrapperTest_cb7fc57440e7a5c6f9ab22298f3cafa4_w300_h240.jpg
-// http://imagecdn.neon-lab.com/CjK/neontnjq3y3e46t6fuzq6hzv16kkgs_WrapperTest_aaa579634777bd96f404ad372ac7a245_w300_h152.jpg
-
 var neonReplacements = {
     'http://img-s-msn-com.akamaized.net/tenant/amp/entityid/BBuXpYG.img?h=516&w=624&m=6&q=60&u=t&o=t&l=f&f=jpg&x=573&y=299': 'http://imagecdn.neon-lab.com/awx/neontnjq3y3e46t6fuzq6hzv16kkgs_WrapperTest_ce93ce468d9ebb7d1bb2c725ae0f764a_w300_h240.jpg',
-    'http://img-s-msn-com.akamaized.net/tenant/amp/entityid/BBuXgQA.img?h=240&w=300&m=6&q=60&u=t&o=t&l=f&f=jpg&x=318&y=104': 'http://imagecdn.neon-lab.com/zK2/neontnjq3y3e46t6fuzq6hzv16kkgs_WrapperTest_f8c4881082bac74d840a2ed6832137cb_w300_h240.jpg'
+    'http://img-s-msn-com.akamaized.net/tenant/amp/entityid/BBuXgQA.img?h=240&w=300&m=6&q=60&u=t&o=t&l=f&f=jpg&x=318&y=104': 'http://imagecdn.neon-lab.com/zK2/neontnjq3y3e46t6fuzq6hzv16kkgs_WrapperTest_f8c4881082bac74d840a2ed6832137cb_w300_h240.jpg',
+    // 'http://img-s-msn-com.akamaized.net/tenant/amp/entityid/BBuXbK0.img?h=100&w=138&m=6&q=60&u=t&o=t&l=f&f=jpg&x=819&y=447': 'http://imagecdn.neon-lab.com/Xuf/neontnjq3y3e46t6fuzq6hzv16kkgs_WrapperTest_d026930a4f64a878691852b1ffc9bd9c_w300_h240.jpg',
+    'http://img-s-msn-com.akamaized.net/tenant/amp/entityid/BBuWPhm.img?h=64&w=85&m=6&q=60&u=t&o=t&l=f&f=jpg&x=434&y=111': 'http://imagecdn.neon-lab.com/0RL/neontnjq3y3e46t6fuzq6hzv16kkgs_WrapperTest_cb7fc57440e7a5c6f9ab22298f3cafa4_w300_h240.jpg',
+    'http://img-s-msn-com.akamaized.net/tenant/amp/entityid/BBuXBPg.img?h=170&w=300&m=6&q=60&u=t&o=t&l=f&f=jpg&x=350&y=177': 'http://imagecdn.neon-lab.com/Xuf/neontnjq3y3e46t6fuzq6hzv16kkgs_WrapperTest_d026930a4f64a878691852b1ffc9bd9c_w300_h240.jpg'
 };
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -18,6 +17,7 @@ function neonTransform(neonReplacements) {
         ;
         images.forEach(function(image) {
             if (image.classList.contains('loaded')) {
+                console.log('Replacement');
                 image.src = value;
             }
         });


### PR DESCRIPTION
# CHANGES
- check for `document.body` existing before using
- tidyup and whitespace
- better constant name
- test file used to inject some content
- change in CDN to be more general `neon-` for now, ugh but this covers the newer CDN and the older (this will need to be configurable at some point)
# TEST PLAN
- this uses `simple` mode, i.e. it looks for the neon images, uses the closest anchor then keeps a note of those to determine clicks
- run a local web server at root
- use Charles to replace (in the response body) `</head>` with `<script src="//localhost:8000/js/utility/msn/replacement.js"></script></head>`
- change `replacement.js` contents to replace images with the Neon/MSN thumbnails
- ensure you can see the IL, IV and IC fire
